### PR TITLE
fix: 포인트 사용 로직 수정

### DIFF
--- a/src/main/java/com/example/connect/domain/match/service/MatchingService.java
+++ b/src/main/java/com/example/connect/domain/match/service/MatchingService.java
@@ -5,6 +5,7 @@ import com.example.connect.domain.match.dto.MatchingResDto;
 import com.example.connect.domain.match.dto.MatchingWithScheduleResDto;
 import com.example.connect.domain.match.entity.Matching;
 import com.example.connect.domain.match.repository.MatchingRepository;
+import com.example.connect.domain.point.service.PointService;
 import com.example.connect.domain.schedule.entity.Schedule;
 import com.example.connect.domain.schedule.repository.ScheduleRepository;
 import com.example.connect.domain.user.entity.User;
@@ -26,6 +27,7 @@ public class MatchingService {
 
     private final MatchingRepository matchingRepository;
     private final ScheduleRepository scheduleRepository;
+    private final PointService pointService;
 
     @Transactional
     public MatchingWithScheduleResDto createMatching(Long userId, Long scheduleId) {
@@ -67,6 +69,10 @@ public class MatchingService {
         matchingRepository.save(matching);
 
         schedule.addCount();
+
+        if (schedule.getCount() > 5) {
+            pointService.usePoint(userId, 1L, "매칭 1회: 50 포인트 사용");
+        }
 
         return new MatchingWithScheduleResDto(scheduleList.get(biggestIndex), matching);
     }

--- a/src/main/java/com/example/connect/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/connect/domain/payment/service/PaymentService.java
@@ -20,6 +20,7 @@ import com.example.connect.global.enums.UserRole;
 import com.example.connect.global.error.errorcode.ErrorCode;
 import com.example.connect.global.error.exception.BadRequestException;
 import com.example.connect.global.error.exception.ForbiddenException;
+import com.example.connect.global.error.exception.NotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -51,7 +52,8 @@ public class PaymentService {
             PaymentReqDto paymentReqDto,
             Long userId
     ) {
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException(ErrorCode.NOT_FOUND));
         DecimalFormat df = new DecimalFormat("###,###");
         String token = portoneService.portoneToken();
 

--- a/src/main/java/com/example/connect/domain/point/service/PointService.java
+++ b/src/main/java/com/example/connect/domain/point/service/PointService.java
@@ -1,166 +1,17 @@
 package com.example.connect.domain.point.service;
 
-import com.example.connect.domain.point.entity.Point;
-import com.example.connect.domain.point.repository.PointRepository;
 import com.example.connect.domain.pointuse.dto.PointUseListResDto;
-import com.example.connect.domain.pointuse.dto.PointUseResDto;
 import com.example.connect.domain.pointuse.entity.PointUse;
-import com.example.connect.domain.pointuse.repository.PointUseRepository;
-import com.example.connect.global.enums.PointUseType;
-import com.example.connect.global.error.errorcode.ErrorCode;
-import com.example.connect.global.error.exception.BadRequestException;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-@Service
-@RequiredArgsConstructor
-public class PointService {
-    private final PointRepository pointRepository;
-    private final PointUseRepository pointUseRepository;
+public interface PointService {
+    void usePoint(Long userId, Long matchingCount, String details);
 
-    public BigDecimal nullToZero(BigDecimal value) {
-        if (value == null) {
-            return BigDecimal.ZERO;
-        }
-        return value;
-    }
+    void expiredPoint(List<PointUse> pointUseList);
 
-    @Transactional
-    public void usePoint(Long userId, Long matchingCount, String details) {
-        BigDecimal totalSpendPoint = BigDecimal.valueOf(matchingCount * 50);
-        PointUse pointInUse = pointUseRepository.findPointInUse(userId);
-        BigDecimal totalHavePoint = totalRemainPoint(userId);
+    PointUseListResDto getAllPoint(Long userId, int page, int size);
 
-        // 1. 사용하려는 포인트가 현재 보유중인 포인트 보다 작은지 확인
-        if (totalSpendPoint.compareTo(totalHavePoint) <= 0) {
-            // 1-1. true : 가장 최근 사용 포인트의 남은 양이 사용 요청 포인트 보다 많은지 확인 && 포인트가 사용되었는지 확인
-            if (
-                    pointInUse.getPointChange().compareTo(totalSpendPoint) >= 0 &&
-                            pointInUse.getAmount().compareTo(BigDecimal.ZERO) != 0
-            ) {
-                // 1-1-1. true : 최근 사용내역에서 포인트 감산
-                PointUse pointUse = new PointUse(
-                        totalSpendPoint,
-                        pointInUse.getPointChange().subtract(totalSpendPoint),
-                        details,
-                        PointUseType.USE,
-                        pointInUse.getPoint()
-                );
-
-                if (pointUse.getPointChange().compareTo(BigDecimal.ZERO) == 0) {
-                    pointUse.getPoint().pointUpdate(true);
-                }
-
-                pointUseRepository.save(pointUse);
-            } else {
-                // 1-1-2. false : 최근 사용내역 포인트 모두 사용 후 다음 포인트 가져옴
-                PointUse updatePoint = pointInUse;
-
-                if (pointInUse.getAmount().compareTo(BigDecimal.ZERO) == 0) {
-                    updatePoint = pointUseRepository.findByOldestPoint(userId);
-                }
-
-                if (totalSpendPoint.compareTo(updatePoint.getPointChange()) >= 0) {
-                    // 소모 포인트가 현제 비교하려는 포인트보다 크거나 같을 경우
-                    BigDecimal spend = totalSpendPoint;
-
-                    while (spend.compareTo(BigDecimal.ZERO) > 0) {
-                        if (spend.compareTo(totalSpendPoint) != 0) {
-                            updatePoint = pointUseRepository.findByOldestPoint(userId);
-                        }
-
-                        int compareCheck = BigDecimal.ZERO.compareTo(updatePoint.getPointChange().subtract(spend));
-
-                        PointUse spendPoint = new PointUse(
-                                compareCheck > 0 ? updatePoint.getPointChange() : spend,
-                                compareCheck > 0 ? BigDecimal.ZERO : updatePoint.getPointChange().subtract(spend),
-                                details,
-                                PointUseType.USE,
-                                updatePoint.getPoint()
-                        );
-
-                        if (compareCheck >= 0) {
-                            spendPoint.getPoint().pointUpdate(true);
-                        }
-
-                        pointUseRepository.save(spendPoint);
-                        spend = spend.subtract(updatePoint.getPointChange());
-                    }
-                } else {
-                    // 소모 포인트가 현재 비교하려는 포인트보다 적을 경우
-                    PointUse spendPoint = new PointUse(
-                            totalSpendPoint,
-                            updatePoint.getPointChange().subtract(totalSpendPoint),
-                            details,
-                            PointUseType.USE,
-                            updatePoint.getPoint()
-                    );
-
-                    pointUseRepository.save(spendPoint);
-                }
-            }
-        } else {
-            // 1-2. false: error message 출력
-            throw new BadRequestException(ErrorCode.LACK_POINT);
-        }
-    }
-
-    /**
-     * 포인트 소멸
-     *
-     * @param pointUseList 소멸 요청될 포인트
-     */
-    @Transactional
-    public void expiredPoint(List<PointUse> pointUseList) {
-        for (PointUse pointUse : pointUseList) {
-            PointUse updatePointUse = new PointUse(
-                    pointUse.getPointChange(),
-                    BigDecimal.ZERO,
-                    "포인트 기간 만료 소멸",
-                    PointUseType.CHANGE,
-                    pointUse.getPoint()
-            );
-
-            Point updatePoint = updatePointUse.getPoint();
-            updatePoint.pointUpdate(true);
-
-            pointRepository.save(updatePoint);
-            pointUseRepository.save(updatePointUse);
-        }
-    }
-
-    public PointUseListResDto getAllPoint(Long userId, int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size);
-        Page<PointUse> pointUseList = pointUseRepository.findByUserId(userId, pageable);
-
-        List<PointUseResDto> pointUseResDtos = pointUseList.getContent().stream().map(data ->
-                new PointUseResDto(
-                        data.getId(),
-                        data.getAmount(),
-                        data.getPointChange(),
-                        data.getDetails(),
-                        data.getPointUseType(),
-                        data.getCreatedAt(),
-                        data.getUpdatedAt()
-                )).toList();
-
-        return new PointUseListResDto(page, size, pointUseList.getTotalElements(), pointUseList.getTotalPages(), pointUseResDtos);
-    }
-
-    public BigDecimal totalRemainPoint(Long userId) {
-        PointUse pointInUse = pointUseRepository.findPointInUse(userId);
-        BigDecimal usingPoint = nullToZero(pointInUse.getPointChange());
-        BigDecimal purePoint = nullToZero(new BigDecimal(pointRepository.sumAmount(userId)));
-
-        BigDecimal totalRemainPoint = usingPoint.compareTo(BigDecimal.ZERO) == 0 ? purePoint : purePoint.add(usingPoint);
-
-        return totalRemainPoint;
-    }
+    BigDecimal totalRemainPoint(Long userId);
 }

--- a/src/main/java/com/example/connect/domain/point/service/PointServiceImpl.java
+++ b/src/main/java/com/example/connect/domain/point/service/PointServiceImpl.java
@@ -1,0 +1,205 @@
+package com.example.connect.domain.point.service;
+
+import com.example.connect.domain.point.entity.Point;
+import com.example.connect.domain.point.repository.PointRepository;
+import com.example.connect.domain.pointuse.dto.PointUseListResDto;
+import com.example.connect.domain.pointuse.dto.PointUseResDto;
+import com.example.connect.domain.pointuse.entity.PointUse;
+import com.example.connect.domain.pointuse.repository.PointUseRepository;
+import com.example.connect.global.enums.PointUseType;
+import com.example.connect.global.error.errorcode.ErrorCode;
+import com.example.connect.global.error.exception.BadRequestException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PointServiceImpl implements PointService {
+    private final PointRepository pointRepository;
+    private final PointUseRepository pointUseRepository;
+
+    private BigDecimal nullToZero(BigDecimal value) {
+        if (value == null) {
+            return BigDecimal.ZERO;
+        }
+        return value;
+    }
+
+    /**
+     * 포인트 사용
+     *
+     * @param matchingCount 매칭 돌릴 횟수
+     * @param details       상세 설명
+     */
+    @Override
+    @Transactional
+    public void usePoint(Long userId, Long matchingCount, String details) {
+        Pageable pageable = PageRequest.of(0, 1);
+        BigDecimal totalSpendPoint = BigDecimal.valueOf(matchingCount * 50);
+        BigDecimal totalHavePoint = totalRemainPoint(userId);
+        List<PointUse> pointUseList = pointUseRepository.findPointInUse(userId, pageable);
+
+        if (totalSpendPoint.compareTo(totalHavePoint) > 0 || pointUseList.isEmpty()) {
+            throw new BadRequestException(ErrorCode.LACK_POINT);
+        }
+
+        PointUse pointInUse = pointUseList.get(0);
+
+        if (
+                nullToZero(pointInUse.getPointChange()).compareTo(totalSpendPoint) >= 0 &&
+                        nullToZero(pointInUse.getAmount()).compareTo(BigDecimal.ZERO) != 0
+        ) {
+            Boolean isPointUpdate = pointInUse.getPointChange().compareTo(BigDecimal.ZERO) == 0;
+
+            pointInUseSave(pointInUse, totalSpendPoint, pointInUse.getPointChange().subtract(totalSpendPoint), details, isPointUpdate);
+
+        } else {
+            PointUse oldestPoint = pointInUse;
+
+            if (nullToZero(pointInUse.getAmount()).compareTo(BigDecimal.ZERO) == 0) {
+                oldestPoint = getOldestPoint(userId, pageable);
+            }
+
+            if (totalSpendPoint.compareTo(oldestPoint.getPointChange()) >= 0) {
+                BigDecimal spend = totalSpendPoint;
+
+                while (spend.compareTo(BigDecimal.ZERO) > 0) {
+
+                    if (spend.compareTo(totalSpendPoint) != 0) {
+                        oldestPoint = getOldestPoint(userId, pageable);
+                    }
+
+                    BigDecimal minAmount = oldestPoint.getPointChange().min(spend);
+                    BigDecimal pointChange = BigDecimal.ZERO.compareTo(oldestPoint.getPointChange().subtract(spend)) > 0
+                            ? BigDecimal.ZERO : oldestPoint.getPointChange().subtract(spend);
+                    Boolean isPointUpdate = BigDecimal.ZERO.compareTo(oldestPoint.getPointChange().subtract(spend)) >= 0;
+
+                    pointInUseSave(oldestPoint, minAmount, pointChange, details, isPointUpdate);
+
+                    spend = spend.subtract(oldestPoint.getPointChange());
+                }
+
+            } else {
+                BigDecimal subPoint = oldestPoint.getPointChange().subtract(totalSpendPoint);
+
+                pointInUseSave(oldestPoint, totalSpendPoint, subPoint, details, false);
+            }
+        }
+    }
+
+    /**
+     * 포인트 사용으로 인한 사용내역 저장
+     *
+     * @param pointInUse    사용중인 포인트 내역
+     * @param amount        포인트 사용 양
+     * @param pointChange   포인트 소모 양
+     * @param details       포인트 사용 내역
+     * @param isPointUpdate 포인트 상태 업데이트 여부
+     */
+    private void pointInUseSave(
+            PointUse pointInUse, BigDecimal amount, BigDecimal pointChange, String details, Boolean isPointUpdate
+    ) {
+        PointUse pointUse = new PointUse(
+                amount,
+                pointChange,
+                details,
+                PointUseType.USE,
+                pointInUse.getPoint()
+        );
+
+        if (isPointUpdate) {
+            pointUse.getPoint().pointUpdate(true);
+        }
+
+        pointUseRepository.save(pointUse);
+    }
+
+    /**
+     * 생성한지 가장 오래된 포인트 조회
+     */
+    private PointUse getOldestPoint(Long userId, Pageable pageable) {
+        List<PointUse> oldestPointList = pointUseRepository.findByOldestPoint(userId, pageable);
+
+        if (oldestPointList.isEmpty()) {
+            throw new BadRequestException(ErrorCode.LACK_POINT);
+        } else {
+            return oldestPointList.get(0);
+        }
+    }
+
+    /**
+     * 포인트 소멸
+     *
+     * @param pointUseList 소멸 요청될 포인트
+     */
+    @Override
+    @Transactional
+    public void expiredPoint(List<PointUse> pointUseList) {
+        for (PointUse pointUse : pointUseList) {
+            PointUse updatePointUse = new PointUse(
+                    pointUse.getPointChange(),
+                    BigDecimal.ZERO,
+                    "포인트 기간 만료 소멸",
+                    PointUseType.CHANGE,
+                    pointUse.getPoint()
+            );
+
+            Point updatePoint = updatePointUse.getPoint();
+            updatePoint.pointUpdate(true);
+
+            pointRepository.save(updatePoint);
+            pointUseRepository.save(updatePointUse);
+        }
+    }
+
+    /**
+     * 포인트 전체 조회
+     */
+    @Override
+    public PointUseListResDto getAllPoint(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<PointUse> pointUseList = pointUseRepository.findByUserId(userId, pageable);
+
+        List<PointUseResDto> pointUseResDtos = pointUseList.getContent().stream().map(data ->
+                new PointUseResDto(
+                        data.getId(),
+                        data.getAmount(),
+                        data.getPointChange(),
+                        data.getDetails(),
+                        data.getPointUseType(),
+                        data.getCreatedAt(),
+                        data.getUpdatedAt()
+                )).toList();
+
+        return new PointUseListResDto(page, size, pointUseList.getTotalElements(), pointUseList.getTotalPages(), pointUseResDtos);
+    }
+
+    /**
+     * 유저 소유 포인트
+     */
+    @Override
+    public BigDecimal totalRemainPoint(Long userId) {
+        Pageable pageable = PageRequest.of(0, 1);
+        List<PointUse> pointUseList = pointUseRepository.findPointInUse(userId, pageable);
+
+        if (!pointUseList.isEmpty()) {
+            PointUse pointInUse = pointUseList.get(0);
+            Long sumAmount = pointRepository.sumAmount(userId);
+
+            BigDecimal usingPoint = nullToZero(pointInUse.getPointChange());
+            BigDecimal purePoint = new BigDecimal(sumAmount == null ? 0 : sumAmount);
+            BigDecimal totalRemainPoint = usingPoint.compareTo(BigDecimal.ZERO) == 0 ? purePoint : purePoint.add(usingPoint);
+
+            return totalRemainPoint;
+        } else {
+            return BigDecimal.ZERO;
+        }
+    }
+}

--- a/src/main/java/com/example/connect/domain/pointuse/repository/PointUseRepository.java
+++ b/src/main/java/com/example/connect/domain/pointuse/repository/PointUseRepository.java
@@ -10,11 +10,11 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PointUseRepository extends JpaRepository<PointUse, Long> {
-    @Query("select pu from PointUse pu where pu.point.id = (select p.id from Point p where p.user.id = :userId and p.isZero = false order by p.createdAt asc limit 1)")
-    PointUse findByOldestPoint(Long userId);
+    @Query("select pu from PointUse pu join pu.point p where p.user.id = :userId and p.isZero = false order by p.createdAt asc")
+    List<PointUse> findByOldestPoint(Long userId, Pageable pageable);
 
-    @Query("select pu from PointUse pu join pu.point p where p.user.id = :userId and pu.pointChange > 0 order by pu.createdAt desc, pu.point.id desc limit 1")
-    PointUse findPointInUse(Long userId);
+    @Query("select pu from PointUse pu join pu.point p where p.user.id = :userId and pu.pointChange > 0 order by pu.createdAt desc, pu.point.id desc")
+    List<PointUse> findPointInUse(Long userId, Pageable pageable);
 
     @Query("select pu from PointUse pu join pu.point p where p.createdAt < :expiredDate and p.isZero = false and pu.createdAt = (select max(ipu.createdAt) from PointUse ipu where ipu.point.id = p.id)")
     List<PointUse> findExpiredPoints(LocalDateTime expiredDate);


### PR DESCRIPTION
### 변경 사항
#120 
- MatchingService에서 포인트 사용
     - service단 결합도 낮추기 위해 point service interface 생성
     - 매칭 시도가 5회가 넘을 경우 point 소모
- 포인트 사용 코드 수정
     - 중복 코드 제거를 위해 메소드 분리
     - 쿼리 limit 1 제거
