### PR TITLE
Feature/auto coupon

### DIFF
--- a/src/main/java/com/example/connect/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/example/connect/domain/coupon/controller/CouponController.java
@@ -10,6 +10,7 @@ import com.example.connect.domain.couponuser.dto.CouponUserUseResDto;
 import com.example.connect.domain.user.dto.RedisUserDto;
 import com.example.connect.global.common.dto.CommonResDto;
 import com.example.connect.global.config.auth.UserDetailsImpl;
+import com.example.connect.global.enums.CouponFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -32,9 +33,10 @@ public class CouponController {
     @GetMapping
     public ResponseEntity<CommonResDto<CouponListResDto>> getAllCoupons(
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "ALL") CouponFilter filter
     ) {
-        CouponListResDto result = couponService.getCouponList(page, size);
+        CouponListResDto result = couponService.getCouponList(page, size, filter);
 
         return new ResponseEntity<>(new CommonResDto<>("쿠폰 조회 완료.", result), HttpStatus.OK);
     }

--- a/src/main/java/com/example/connect/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/connect/domain/coupon/repository/CouponRepository.java
@@ -19,4 +19,6 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
     Page<CouponResDto> findByOrderByCreatedAtDesc(Pageable pageable);
 
     List<Coupon> findByExpiredDateIsLessThanEqual(LocalDate now);
+
+    Coupon findByName(String name);
 }

--- a/src/main/java/com/example/connect/domain/coupon/repository/CouponRepository.java
+++ b/src/main/java/com/example/connect/domain/coupon/repository/CouponRepository.java
@@ -1,22 +1,17 @@
 package com.example.connect.domain.coupon.repository;
 
-import com.example.connect.domain.coupon.dto.CouponResDto;
 import com.example.connect.domain.coupon.entity.Coupon;
 import com.example.connect.global.error.errorcode.ErrorCode;
 import com.example.connect.global.error.exception.NotFoundException;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long> {
+public interface CouponRepository extends JpaRepository<Coupon, Long>, CustomCouponRepository {
     default Coupon findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
     }
-
-    Page<CouponResDto> findByOrderByCreatedAtDesc(Pageable pageable);
 
     List<Coupon> findByExpiredDateIsLessThanEqual(LocalDate now);
 

--- a/src/main/java/com/example/connect/domain/coupon/repository/CustomCouponRepository.java
+++ b/src/main/java/com/example/connect/domain/coupon/repository/CustomCouponRepository.java
@@ -1,0 +1,10 @@
+package com.example.connect.domain.coupon.repository;
+
+import com.example.connect.domain.coupon.dto.CouponResDto;
+import com.example.connect.global.enums.CouponFilter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomCouponRepository {
+    Page<CouponResDto> findByOrderByCreatedAtDesc(CouponFilter filter, Pageable pageable);
+}

--- a/src/main/java/com/example/connect/domain/coupon/repository/CustomCouponRepositoryImpl.java
+++ b/src/main/java/com/example/connect/domain/coupon/repository/CustomCouponRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.example.connect.domain.coupon.repository;
+
+import com.example.connect.domain.coupon.dto.CouponResDto;
+import com.example.connect.domain.coupon.entity.QCoupon;
+import com.example.connect.global.enums.CouponFilter;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CustomCouponRepositoryImpl implements CustomCouponRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CouponResDto> findByOrderByCreatedAtDesc(CouponFilter filter, Pageable pageable) {
+        QCoupon c = QCoupon.coupon;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        builder.and(c.count.gt(0));
+
+        if (Objects.equals(filter, CouponFilter.ISSUED_COUPON)) {
+            builder.and(c.openDate.before(LocalDateTime.now()).or(c.openDate.eq(LocalDateTime.now())));
+            orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, c.expiredDate));
+        } else if (Objects.equals(filter, CouponFilter.WAITING_COUPON)) {
+            builder.and(c.openDate.after(LocalDateTime.now()));
+            orderSpecifiers.add(new OrderSpecifier<>(Order.ASC, c.openDate));
+        }
+
+        orderSpecifiers.add(new OrderSpecifier<>(Order.DESC, c.createdAt));
+        
+        List<CouponResDto> coupons = queryFactory.select(Projections.constructor(CouponResDto.class, c))
+                .from(c)
+                .where(builder)
+                .orderBy(orderSpecifiers.toArray(OrderSpecifier[]::new))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(queryFactory.select(c.count())
+                .from(c)
+                .where(builder)
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(coupons, pageable, total);
+    }
+
+}

--- a/src/main/java/com/example/connect/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/connect/domain/coupon/service/CouponService.java
@@ -14,6 +14,7 @@ import com.example.connect.domain.schedule.entity.Schedule;
 import com.example.connect.domain.schedule.repository.ScheduleRepository;
 import com.example.connect.domain.user.entity.User;
 import com.example.connect.domain.user.repository.UserRepository;
+import com.example.connect.global.enums.CouponFilter;
 import com.example.connect.global.enums.CouponUserStatus;
 import com.example.connect.global.error.errorcode.ErrorCode;
 import com.example.connect.global.error.exception.BadRequestException;
@@ -39,9 +40,9 @@ public class CouponService {
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
 
-    public CouponListResDto getCouponList(int page, int size) {
+    public CouponListResDto getCouponList(int page, int size, CouponFilter filter) {
         Pageable pageable = PageRequest.of(page - 1, size);
-        Page<CouponResDto> coupons = couponRepository.findByOrderByCreatedAtDesc(pageable);
+        Page<CouponResDto> coupons = couponRepository.findByOrderByCreatedAtDesc(filter, pageable);
 
         CouponListResDto resDto = new CouponListResDto(
                 page, size, coupons.getTotalElements(), coupons.getTotalPages(), coupons.getContent()

--- a/src/main/java/com/example/connect/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/example/connect/domain/coupon/service/CouponService.java
@@ -174,7 +174,7 @@ public class CouponService {
         Coupon coupon = new Coupon(
                 birthYear + " 년 생일 쿠폰",
                 birthYear + " 생일을 축하드립니다!",
-                Integer.MAX_VALUE,
+                1,
                 5,
                 LocalDate.of(Integer.parseInt(birthYear), 12, 31).plusDays(14),
                 LocalDateTime.of(Integer.parseInt(birthYear), 12, 31, 0, 0, 0).plusDays(14)

--- a/src/main/java/com/example/connect/domain/couponuser/entity/CouponUser.java
+++ b/src/main/java/com/example/connect/domain/couponuser/entity/CouponUser.java
@@ -71,8 +71,4 @@ public class CouponUser extends BaseEntity {
     public void isUse() {
         this.status = CouponUserStatus.USED;
     }
-
-    public void isDelete() {
-        this.isDeleted = true;
-    }
 }

--- a/src/main/java/com/example/connect/domain/couponuser/repository/CouponUserRepository.java
+++ b/src/main/java/com/example/connect/domain/couponuser/repository/CouponUserRepository.java
@@ -6,6 +6,9 @@ import com.example.connect.global.error.exception.NotFoundException;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface CouponUserRepository extends JpaRepository<CouponUser, Long>, CustomCouponUserRepository {
     default CouponUser findByIdOrElseThrow(Long id) {
         return findById(id).orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND));
@@ -15,4 +18,6 @@ public interface CouponUserRepository extends JpaRepository<CouponUser, Long>, C
     Long countCouponUseId(Long couponId);
 
     boolean existsByCouponIdAndUserId(Long couponId, Long userId);
+
+    List<CouponUser> findByExpiredDateIsLessThanEqual(LocalDate expiredDate);
 }

--- a/src/main/java/com/example/connect/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/connect/domain/user/repository/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, CustomUserRepository {
@@ -22,4 +23,7 @@ public interface UserRepository extends JpaRepository<User, Long>, CustomUserRep
 
     @Query(value = "SELECT COUNT(email) > 0 FROM user WHERE email = :email", nativeQuery = true)
     int existsByEmail(@Param("email") String email);
+
+    @Query("select u from User u where u.birth like concat('%', :birth)")
+    List<User> findByBirth(@Param("birth") String birth);
 }

--- a/src/main/java/com/example/connect/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/connect/domain/user/service/AuthService.java
@@ -1,5 +1,9 @@
 package com.example.connect.domain.user.service;
 
+import com.example.connect.domain.coupon.entity.Coupon;
+import com.example.connect.domain.coupon.repository.CouponRepository;
+import com.example.connect.domain.couponuser.entity.CouponUser;
+import com.example.connect.domain.couponuser.repository.CouponUserRepository;
 import com.example.connect.domain.membership.entity.Membership;
 import com.example.connect.domain.membership.repository.MembershipRepository;
 import com.example.connect.domain.user.dto.RedisUserDto;
@@ -11,6 +15,7 @@ import com.example.connect.domain.user.repository.RedisEmailRepository;
 import com.example.connect.domain.user.repository.RedisTokenRepository;
 import com.example.connect.domain.user.repository.UserRepository;
 import com.example.connect.global.common.dto.TokenDto;
+import com.example.connect.global.enums.CouponUserStatus;
 import com.example.connect.global.error.errorcode.ErrorCode;
 import com.example.connect.global.error.exception.BadRequestException;
 import com.example.connect.global.error.exception.UnAuthorizedException;
@@ -34,6 +39,8 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RedisTokenRepository redisTokenRepository;
     private final RedisEmailRepository redisEmailRepository;
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
 
     public SignupResDto signup(SignupServiceDto signupServiceDto) {
 
@@ -50,6 +57,7 @@ public class AuthService {
         User savedUser = userRepository.save(user);
 
         redisEmailRepository.deleteEmailStatus(signupServiceDto.getEmail());
+        createSignUpCoupon(savedUser);
 
         return new SignupResDto(savedUser);
     }
@@ -97,5 +105,19 @@ public class AuthService {
         }
 
         return jwtProvider.generateToken(sessionUser);
+    }
+
+    public void createSignUpCoupon(User user) {
+        LocalDate expiredDate = LocalDate.now().plusDays(14);
+        Coupon coupon = couponRepository.findByName("가입 축하 쿠폰");
+
+        CouponUser couponUser = new CouponUser(
+                expiredDate,
+                CouponUserStatus.UNUSED,
+                user,
+                coupon
+        );
+
+        couponUserRepository.save(couponUser);
     }
 }

--- a/src/main/java/com/example/connect/global/config/SchedulerConfig.java
+++ b/src/main/java/com/example/connect/global/config/SchedulerConfig.java
@@ -25,5 +25,11 @@ public class SchedulerConfig {
 
         pointService.expiredPoint(pointUseList);
         couponService.expireCoupon();
+        couponService.createBirthCouponUser();
+    }
+
+    @Scheduled(cron = "0 0 0 1 1 *")
+    public void creteBirthCoupon() {
+        couponService.createBirthCoupon();
     }
 }

--- a/src/main/java/com/example/connect/global/enums/CouponFilter.java
+++ b/src/main/java/com/example/connect/global/enums/CouponFilter.java
@@ -1,0 +1,7 @@
+package com.example.connect.global.enums;
+
+public enum CouponFilter {
+    ALL,
+    ISSUED_COUPON,
+    WAITING_COUPON;
+}


### PR DESCRIPTION
#145 

쿠폰 조회 수정
- 유저 단 배포중인 쿠폰만 확인 가능하도록 수정
- 유저, 어드민 단 각각 다른 정렬 적용

가입 축하 쿠폰 자동 배포
- 가입 축하용으로 사용될 쿠폰 DB에 생성 필요

생일 축하 쿠폰 자동 생성 및 배포
- 매년 1일 생성, 후년 1월 14일 삭제
- 쿠폰 발급 후 2주간 사용 가능

가입, 생일 쿠폰의 경우 배포 수를 0으로 잡아야 합니다.