### PR TITLE
hotfix: 채팅방, 채팅 내역 삭제 오류

### DIFF
--- a/src/main/java/com/example/connect/domain/chat/service/ChatroomService.java
+++ b/src/main/java/com/example/connect/domain/chat/service/ChatroomService.java
@@ -75,11 +75,11 @@ public class ChatroomService {
 
     // 채팅 내역 및 채팅방 삭제
     private void deleteAllAboutChatAndChatroom(Long chatroomId) {
-        // 1. 중간 테이블 삭제
-        userChatroomRepository.deleteAllByChatroomId(chatroomId);
-
-        // 2. 채팅방의 채팅 내역 삭제
+        // 1. 채팅방의 채팅 내역 삭제
         chatRepository.deleteAllByChatroomId(chatroomId);
+
+        // 2. 중간 테이블 삭제
+        userChatroomRepository.deleteAllByChatroomId(chatroomId);
 
         // 2. 채팅방 삭제
         chatroomRepository.deleteById(chatroomId);


### PR DESCRIPTION
• 채팅방의 마지막 유저가 삭제하는 경우, 채팅방 및 채팅 내역 삭제 부분에서 SQL 오류 수정했습니다.

• 오류 내용: user_chatroom 테이블이 먼저 삭제되어서 연관관계를 가지는 chat에 null 값이 들어가 오류 발생